### PR TITLE
Clear actionbar

### DIFF
--- a/actionbar/src/com/markupartist/android/widget/ActionBar.java
+++ b/actionbar/src/com/markupartist/android/widget/ActionBar.java
@@ -181,6 +181,15 @@ public class ActionBar extends RelativeLayout implements OnClickListener {
         mActionsView.addView(inflateAction(action), index);
     }
 
+
+    /**
+     * Removes all action views from this action bar
+     */
+    public void removeAllActions() {
+        mActionsView.removeAllViews();
+    }
+
+
     /**
      * Inflates a {@link View} with the given {@link Action}.
      * @param action the action to inflate

--- a/actionbarexample/res/layout/main.xml
+++ b/actionbarexample/res/layout/main.xml
@@ -28,5 +28,10 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Stop Progress" />
+        <Button
+                android:id="@+id/remove_actions"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Clear actionbar" />
     </LinearLayout>
 </LinearLayout>

--- a/actionbarexample/src/com/markupartist/android/actionbar/example/HomeActivity.java
+++ b/actionbarexample/src/com/markupartist/android/actionbar/example/HomeActivity.java
@@ -39,6 +39,16 @@ public class HomeActivity extends Activity {
                 actionBar.setProgressBarVisibility(View.GONE);
             }
         });
+
+        Button removeActions = (Button) findViewById(R.id.remove_actions);
+        removeActions.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                actionBar.removeAllActions();
+            }
+        });
+
+
     }
 
     public static Intent createIntent(Context context) {


### PR DESCRIPTION
I find myself needing to change the items in the actionbar at runtime.  Since we don't yet have a way to name actionbar items and access them by id, I _believe_ my best option is to reset the displayed actions and go from there. 

This commit adds an API to do just that.
