### PR TITLE
Added styles to home logo so margins can be styled

### DIFF
--- a/actionbar/res/layout/actionbar.xml
+++ b/actionbar/res/layout/actionbar.xml
@@ -34,6 +34,7 @@
             android:layout_height="@dimen/actionbar_height"
             android:background="@drawable/actionbar_btn"
             android:padding="0dip"
+            style="@style/ActionBarHomeLogo"
             android:visibility="gone"
             />
         <RelativeLayout

--- a/actionbar/res/values/styles.xml
+++ b/actionbar/res/values/styles.xml
@@ -30,6 +30,10 @@
         <item name="android:layout_marginRight">1px</item>
         <item name="android:layout_marginLeft">0px</item>
     </style>
+    <style name="ActionBarHomeLogo">
+        <item name="android:layout_marginRight">1px</item>
+        <item name="android:layout_marginLeft">0px</item>
+    </style>
     <style name="ActionBarProgressBar" parent="@android:style/Widget.ProgressBar.Small">
     </style>
 </resources>


### PR DESCRIPTION
Added a style to home logo (ActionBarHomeLogo) so that margins can be set on the home logo image (vs. having to modify images to contain margins). 
