### PR TITLE
Different item style for the home item

### DIFF
--- a/actionbar/res/layout/actionbar_item_home.xml
+++ b/actionbar/res/layout/actionbar_item_home.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2010 Johan Nilsson <http://markupartist.com>
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<ImageButton xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/actionbar_item"
+    style="?attr/actionBarHomeItemStyle"
+    android:layout_centerVertical="true"
+    android:singleLine="true"
+    android:visibility="visible"
+    />

--- a/actionbar/src/com/markupartist/android/widget/ActionBar.java
+++ b/actionbar/src/com/markupartist/android/widget/ActionBar.java
@@ -1349,7 +1349,9 @@ public class ActionBar extends RelativeLayout {
             mTitle = title;
             mIsEnabled = true;
 
-            mView = mActionBar.mInflater.inflate(R.layout.actionbar_item, mActionBar.mActionsView, false);
+            int layoutId = (itemId == R.id.actionbar_item_home) ? R.layout.actionbar_item_home : R.layout.actionbar_item;
+
+            mView = mActionBar.mInflater.inflate(layoutId, mActionBar.mActionsView, false);
             mView.setTag(this);
             mView.setOnClickListener(mActionBar.mActionClicked);
 

--- a/actionbarexample/res/values/styles.xml
+++ b/actionbarexample/res/values/styles.xml
@@ -39,12 +39,12 @@
         <item name="actionBarTabTextStyle">@style/FancyTabText</item>
         <item name="actionBarStyle">@style/BlueActionBar</item>
         <item name="actionBarItemStyle">@style/BlueActionBarItem</item>
+        <item name="actionBarHomeItemStyle">@style/BlueActionBarItem</item>
         <item name="actionBarItemDivider">@color/blue_actionbar_divider</item>
         <!-- These are the resources needed by the action bar, they all refer
              to default values. -->
         <item name="actionBarTitleTextStyle">@style/ActionBar.TitleText</item>
         <item name="actionBarSubtitleTextStyle">@style/ActionBar.SubtitleText</item>
-        <item name="actionBarHomeItemStyle">@style/ActionBar.HomeItem</item>
         <item name="actionBarHomeLogoStyle">@style/ActionBar.HomeLogo</item>
         <item name="actionBarProgressBarStyle">@style/ActionBar.ProgressBar</item>
     </style>


### PR DESCRIPTION
I felt the need to style the action bar home item independently from all other items (and title) and after digging a little bit into the library code, I come up with this.

It looked to me that the ActionBar_HomeItem style was defined but not being used anywhere. I basically put it to some use... Hopefully, this is the way to go to solve this particular issue.

**This does not change any of the current behavior in the library. Everyone can easily upgrade without making any changes to their apps. Everything will still work perfectly fine.**

P.S: What mess on #53, just ignore it please (I still have a bit to learn on git). This one is clean and it's easy to merge I assume...
