### PR TITLE
Use more appropriate themes on API level 11 and above

### DIFF
--- a/actionbar/res/values-v11/styles.xml
+++ b/actionbar/res/values-v11/styles.xml
@@ -14,6 +14,8 @@
      limitations under the License.
 -->
 <resources>
-    <style name="Theme.ActionBar.InternalBase" parent="@android:style/Theme.Holo.NoActionBar"></style>
-    <style name="Theme.ActionBar.InternalBase.Light" parent="@style/Theme.Holo.Light.NoActionBar"></style>
+    <style name="Theme.Holo.Light.NoActionBar" parent="@android:style/Theme.Holo.Light">
+        <item name="android:windowActionBar">false</item>
+        <item name="android:windowNoTitle">true</item>
+    </style>
 </resources>

--- a/actionbar/res/values-v11/themes.xml
+++ b/actionbar/res/values-v11/themes.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 <resources>
-    <style name="Theme.ActionBar.InternalBase" parent="@android:style/Theme.Holo"></style>
-    <style name="Theme.ActionBar.InternalBase.Light" parent="@android:style/Theme.Holo.Light"></style>
+    <style name="Theme.ActionBar.InternalBase" parent="@android:style/Theme.Holo.NoActionBar"></style>
+    <style name="Theme.ActionBar.InternalBase.Light" parent="@android:style/Theme.Holo.Light.NoActionBar"></style>
 </resources>

--- a/actionbar/res/values-v14/themes.xml
+++ b/actionbar/res/values-v14/themes.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 <resources>
-    <style name="Theme.ActionBar.InternalBase" parent="@android:style/Theme.DeviceDefault"></style>
-    <style name="Theme.ActionBar.InternalBase.Light" parent="@android:style/Theme.DeviceDefault.Light"></style>
+    <style name="Theme.ActionBar.InternalBase" parent="@android:style/Theme.DeviceDefault.NoActionBar"></style>
+    <style name="Theme.ActionBar.InternalBase.Light" parent="@android:style/Theme.DeviceDefault.Light.NoActionBar"></style>
 </resources>

--- a/actionbar/res/values/themes.xml
+++ b/actionbar/res/values/themes.xml
@@ -14,11 +14,14 @@
      limitations under the License.
 -->
 <resources>
-    <style name="Theme.ActionBar.InternalBase" parent="@android:style/Theme"></style>
-    <style name="Theme.ActionBar.InternalBase.Light" parent="@android:style/Theme.Light"></style>
+    <style name="Theme.ActionBar.InternalBase" parent="@android:style/Theme">
+        <item name="android:windowNoTitle">true</item>
+    </style>
+    <style name="Theme.ActionBar.InternalBase.Light" parent="@android:style/Theme.Light">
+        <item name="android:windowNoTitle">true</item>
+    </style>
 
     <style name="Theme.ActionBar" parent="Theme.ActionBar.InternalBase">
-        <item name="android:windowNoTitle">true</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="actionBarStyle">@style/ActionBar.Container</item>
         <item name="actionBarTitleTextStyle">@style/ActionBar.TitleText</item>
@@ -34,7 +37,6 @@
     </style>
 
     <style name="Theme.ActionBar.Light" parent="Theme.ActionBar.InternalBase.Light">
-        <item name="android:windowNoTitle">true</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="actionBarStyle">@style/ActionBar.Container</item>
         <item name="actionBarTitleTextStyle">@style/ActionBar.TitleText</item>


### PR DESCRIPTION
I found a small bug on Android which we introduced in the ActionBar on 4caf6f3637daabd011107a2e669f9b95e8618139. The problem exists in the `Light` theme which I'm using in my app. This bug does not exist on the `Default/Dark` theme, that's why I noticed it in the first place.

This particular bug happens with all kinds of "popup" windows, like a `ContextMenu` or an `AlertDialog`. In the image below you can look at the problem on the `Light` theme, but everything's fine on the `Dark/Default` version:

![](https://lh5.googleusercontent.com/-_SscskAhxFw/TxCzO3jd_II/AAAAAAAAADs/CRFwLEyTFno/s1600/theme-devicedefault.png)

This issue aims to fix it by using the `.NoActionBar` sub-theme instead, which, apparently, don't show this weird bug. It actually makes more sense to use this theme **in this specific library**, which is an ActionBar replacement.

For now, this is the solution, and hopefully, it doesn't have any side-effects. However, I already reported the problem to [Adam Powell](https://plus.google.com/107708120842840792570) and he said he would look into it. I'll be monitoring this problem and if there's any reason to reverse this commit (or maybe change it a little), I'll fix it as soon as possible. In the mean time, I think it's safe to use this`.NoActionBar` sub-theme.
