### PR TITLE
Fixes scrolling title/subtitle text on ICS

### DIFF
--- a/actionbar/res/layout/actionbar.xml
+++ b/actionbar/res/layout/actionbar.xml
@@ -94,6 +94,7 @@
                 style="?attr/actionBarTitleTextStyle"
                 android:layout_alignParentLeft="true"
                 android:layout_toLeftOf="@id/actionbar_progress"
+                android:singleLine="true"
                 />
             <com.markupartist.android.widget.ScrollingTextView
                 android:id="@+id/actionbar_subtitle"
@@ -101,6 +102,7 @@
                 android:layout_alignParentLeft="true"
                 android:layout_toLeftOf="@id/actionbar_progress"
                 android:layout_below="@id/actionbar_title"
+                android:singleLine="true"
                 android:visibility="gone"
                 />
             <FrameLayout


### PR DESCRIPTION
I've noticed this problem in ICS and this fixes it. I'm not sure if not having a single line for the title/subtitle is an expected feature but this is the way to fix the problem on ICS.
